### PR TITLE
Fix Travis builds failing when installing the JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.11.12
   - 2.12.4


### PR DESCRIPTION
Changes travis jdk vendor from oracle to openjdk since oracle doesn't support jdk version 8 anymore.  
Could also be updated to a newer version instead. Opinions?