### PR TITLE
cross build scala-native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val commonSettings = Seq(
 
 enablePlugins(ScalaJSPlugin)
 
-lazy val chameleon = crossProject(JSPlatform, JVMPlatform)
+lazy val chameleon = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .settings(commonSettings)
   .settings(
@@ -65,7 +65,7 @@ lazy val chameleon = crossProject(JSPlatform, JVMPlatform)
     })
   )
 
-lazy val http4s = crossProject(JSPlatform, JVMPlatform)
+lazy val http4s = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .dependsOn(chameleon)
   .settings(commonSettings)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -15,14 +15,14 @@ object Deps {
   val scalapb = dep("com.thesamet.scalapb" %%% "scalapb-runtime" % "0.11.17")
 
   val circe = new {
-    private val version = "0.14.1"
+    private val version = "0.14.9"
     val core = dep("io.circe" %%% "circe-core" % version)
     val parser = dep("io.circe" %%% "circe-parser" % version)
   }
   val scodec = new {
     val core = dep("org.scodec" %%% "scodec-core" % "1.11.10")
     val core2 = dep("org.scodec" %%% "scodec-core" % "2.3.1")
-    val bits = dep("org.scodec" %%% "scodec-bits" % "1.1.38")
+    val bits = dep("org.scodec" %%% "scodec-bits" % "1.2.0")
   }
   val upickle = dep("com.lihaoyi" %%% "upickle" % "3.3.1")
   val jsoniter = dep("com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.30.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,9 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.4")
+
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")


### PR DESCRIPTION
Currently does not work yet, because zio-json is only released for scala-native version 0.4 (and not yet 0.5).
And `scodec-core` version 1 (which is needed for scala `2.12` and `2.13`) is not released for scala native. Only version 2 is, but that only exists for scala 3 :)

So, I guess, we either need to wait more. Or we rethink the design with one artifact having optional dependencies, and have multiple projects instead. Or we include the dependencies only for the supported platforms (jsSettings, nativeSettings, ...) and put the corresponding code into platform-specific directories.
